### PR TITLE
Only retrieve 3rd party packages | Improve screenshot tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ adbfriend mcp server --sse true
 | force-stop-process             | Forces the stop of provided package names on an Android device.                                           |
 | uninstall-package              | Uninstalls provided package names on an Android device.                                                   |
 | get-connected-devices          | Retrieves information about all connected Android devices including serial, model, and state.             |
-| get-installed-packages         | Retrieves information about all installed packages on an Android device.                                  |
+| get-installed-packages         | Retrieves information about all installed packages on an Android device. Supports filtering for third-party apps only. |
 | list_allowed_directories       | Lists directories that are allowed to be accessed by the file system tools.                               |
 | list-files                     | Lists files and directories on an Android device. Supports recursive listing with the 'recursive' option. |
 | read-file                      | Reads the content of a file on an Android device.                                                         |

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CaptureScreenshotTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CaptureScreenshotTool.kt
@@ -1,9 +1,8 @@
 package com.mikepenz.adbfriend.subcommands.mcp.tools
 
 import com.malinskiy.adam.AndroidDebugBridgeClient
-import com.malinskiy.adam.request.Feature
-import com.malinskiy.adam.request.shell.v2.ShellCommandRequest
-import com.malinskiy.adam.request.sync.v2.PullFileRequest
+import com.malinskiy.adam.request.framebuffer.RawImageScreenCaptureAdapter
+import com.malinskiy.adam.request.framebuffer.ScreenCaptureRequest
 import com.mikepenz.adbfriend.subcommands.mcp.exception.ToolException
 import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputOutputPath
@@ -11,12 +10,10 @@ import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import java.io.File
+import javax.imageio.ImageIO
 
 fun createCaptureScreenshotTool(adb: AndroidDebugBridgeClient, hostAllowedPaths: List<String>? = null): RegisteredTool = createTool(
     name = "capture-screenshot",
@@ -39,44 +36,15 @@ fun createCaptureScreenshotTool(adb: AndroidDebugBridgeClient, hostAllowedPaths:
     }
 
     // Capture screenshot on the device
-    val deviceScreenshotPath = "/sdcard/adbfriend-screenshot.png"
-    val captureResult = adb.execute(
-        request = ShellCommandRequest("screencap -p $deviceScreenshotPath"),
+    val adapter = RawImageScreenCaptureAdapter()
+    val image = adb.execute(
+        request = ScreenCaptureRequest(adapter),
         serial = serial
-    )
+    ).toBufferedImage()
 
-    if (captureResult.exitCode != 0) {
-        throw ToolException("Failed to capture screenshot: ${captureResult.output}")
-    }
-
-    // Pull the screenshot from the device to the host
     val outputFile = File(outputPath)
-    try {
-        withContext(Dispatchers.IO) {
-            outputFile.parentFile?.mkdirs()
-            val pullChannel = adb.execute(
-                request = PullFileRequest(
-                    remotePath = deviceScreenshotPath,
-                    local = outputFile,
-                    supportedFeatures = listOf(Feature.LS_V2, Feature.STAT_V2, Feature.SENDRECV_V2)
-                ),
-                scope = CoroutineScope(Dispatchers.IO),
-                serial = serial
-            )
-
-            @Suppress("ControlFlowWithEmptyBody")
-            for (percentageDouble in pullChannel) {
-                // wait until the file is fully pulled
-            }
-
-            // Clean up the temporary file on the device
-            adb.execute(
-                request = ShellCommandRequest("rm $deviceScreenshotPath"),
-                serial = serial
-            )
-        }
-    } catch (e: Exception) {
-        throw ToolException("Failed to pull screenshot from device: ${e.message}")
+    if (!ImageIO.write(image, "png", outputFile)) {
+        throw ToolException("Failed to capture screenshot: $outputPath")
     }
 
     // Return the result

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListInstalledPackagesTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListInstalledPackagesTool.kt
@@ -21,16 +21,41 @@ fun createGetInstalledPackagesTool(adb: AndroidDebugBridgeClient): RegisteredToo
         Retrieves the information of all installed packages on the Android device for the provided serial.
         For each installed package `packageName`, `version` and `dataDir` will be returned.
         The `packageName` is the common identifier used to access any other package specific tool.
+        Use the `third-party-only` flag to filter out system applications and only show third-party applications.
     """.trimIndent(),
     inputSchema = DEVICE_FILTER_TOOL_INPUT
 ) {
     val serial = inputSerial
 
     val packageGlob = arguments["package-filter"]?.jsonPrimitive?.content
+    val thirdPartyOnly = arguments["third-party-only"]?.jsonPrimitive?.content?.toBoolean() ?: false
     val regex = if (packageGlob != null) convertGlobToRegex(packageGlob) else null
+
+    // Get all packages using dumpsys
     val response = adb.execute(request = ShellCommandRequest("dumpsys package packages"), serial = serial)
     val packages = packageParser(response.output) { }
-    val filtered = if (regex != null) packages.filter { regex.matches(it.packageName) } else packages
+
+    // Apply filters
+    var filtered = packages
+
+    // Apply third-party only filter if enabled
+    if (thirdPartyOnly) {
+        // Use pm list packages -3 to get third-party packages
+        val thirdPartyResponse = adb.execute(request = ShellCommandRequest("pm list packages -3"), serial = serial)
+        val thirdPartyPackageNames = thirdPartyResponse.output
+            .lineSequence()
+            .filter { it.startsWith("package:") }
+            .map { it.substring("package:".length) }
+            .toSet()
+
+        // Filter packages based on the list from pm list packages -3
+        filtered = filtered.filter { thirdPartyPackageNames.contains(it.packageName) }
+    }
+
+    // Apply package name filter if provided
+    if (regex != null) {
+        filtered = filtered.filter { regex.matches(it.packageName) }
+    }
 
     val result = buildJsonObject {
         put("packages", buildJsonArray {

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/Spec.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/Spec.kt
@@ -30,7 +30,12 @@ internal val DEVICE_FILTER_TOOL_INPUT = Tool.Input(
     properties = JsonObject(
         mapOf(
             "serial" to SERIAL_INPUT,
-            "package-filter" to PACKAGE_FILTER_INPUT
+            "package-filter" to PACKAGE_FILTER_INPUT,
+            "third-party-only" to buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("If true, only third-party applications will be included in the results"))
+                put("default", JsonPrimitive(true))
+            }
         )
     ),
     required = listOf("serial")


### PR DESCRIPTION
- add ability to only get 3rd party packages instead of all
- simplify and optimize getting the screenshot from the device