### PR TITLE
Upgrade project to latest mcp with structured output | Upgrade environment

### DIFF
--- a/adbfriend-cli/build.gradle.kts
+++ b/adbfriend-cli/build.gradle.kts
@@ -31,7 +31,6 @@ kotlin {
 
 application {
     applicationName = "adbfriend"
-    mainModule = "com.mikepenz.adbfriend.app"
     mainClass = "com.mikepenz.adbfriend.MainKt"
     version = property("VERSION_NAME").toString()
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/Server.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/Server.kt
@@ -21,8 +21,12 @@ class SseOptions : OptionGroup() {
 class Server : AdbCommand() {
     val sseOptions by SseOptions().cooccurring()
     val tools by option().flag()
-    val allowedPaths: List<String> by option(help = "List of allowed paths for file system operations on the Android device", envvar = "adbfriend-allowed-paths").varargValues().default(DEFAULT_ALLOWED_PATHS)
-    val hostAllowedPaths: List<String> by option(help = "List of allowed paths for file system operations on the host system", envvar = "adbfriend-host-allowed-paths").varargValues().default(getDefaultHostAllowedPaths())
+    val allowedPaths: List<String> by option(help = "List of allowed paths for file system operations on the Android device", envvar = "adbfriend-allowed-paths").varargValues()
+        .default(DEFAULT_ALLOWED_PATHS)
+    val hostAllowedPaths: List<String> by option(
+        help = "List of allowed paths for file system operations on the host system",
+        envvar = "adbfriend-host-allowed-paths"
+    ).varargValues().default(getDefaultHostAllowedPaths())
 
     override val requireAdbServer = false
     override val failOnNoDevice = false

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CaptureScreenshotTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CaptureScreenshotTool.kt
@@ -4,11 +4,12 @@ import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.framebuffer.RawImageScreenCaptureAdapter
 import com.malinskiy.adam.request.framebuffer.ScreenCaptureRequest
 import com.mikepenz.adbfriend.subcommands.mcp.exception.ToolException
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
 import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputOutputPath
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.Tool
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -21,7 +22,24 @@ fun createCaptureScreenshotTool(adb: AndroidDebugBridgeClient, hostAllowedPaths:
         Captures a screenshot from the Android device, saves it temporarily, and then transfers it to the specified output path on the host system.
         Use with caution as this can overwrite existing files on the host system.
     """.trimIndent(),
-    inputSchema = CAPTURE_SCREENSHOT_TOOL_INPUT
+    inputSchema = CAPTURE_SCREENSHOT_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the screenshot was captured successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("screenshot_path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path where the screenshot was saved on the host system"))
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        // Add additional metadata about the tool
+        this
+    }
 ) {
     val serial = inputSerial
     val outputPath = inputOutputPath
@@ -49,9 +67,10 @@ fun createCaptureScreenshotTool(adb: AndroidDebugBridgeClient, hostAllowedPaths:
 
     // Return the result
     CallToolResult(
-        content = listOf(TextContent(buildJsonObject {
+        structuredContent = buildJsonObject {
             put("success", JsonPrimitive(true))
             put("screenshot_path", JsonPrimitive(outputPath))
-        }.toString()))
+        },
+        content = listOf()
     )
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CaptureScreenshotTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CaptureScreenshotTool.kt
@@ -37,8 +37,11 @@ fun createCaptureScreenshotTool(adb: AndroidDebugBridgeClient, hostAllowedPaths:
         required = listOf("success")
     ),
     annotations = {
-        // Add additional metadata about the tool
-        this
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
     }
 ) {
     val serial = inputSerial

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CheckAdbSpeedTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CheckAdbSpeedTool.kt
@@ -1,15 +1,17 @@
 package com.mikepenz.adbfriend.subcommands.mcp.tools
 
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
+import com.mikepenz.adbfriend.subcommands.mcp.utils.asStructuredResponse
+import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
+import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import com.mikepenz.adbfriend.utils.usbProtocolParser
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import java.util.concurrent.TimeUnit
 
 fun createCheckAdbSpeedTool(): RegisteredTool = createTool(
@@ -17,7 +19,17 @@ fun createCheckAdbSpeedTool(): RegisteredTool = createTool(
     description = """
         Checks the usb connection speed of the Android device for the provided serial.
     """.trimIndent(),
-    inputSchema = DEVICE_FILTER_TOOL_INPUT
+    inputSchema = DEVICE_FILTER_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(messageDescription = "A message containing the USB connection speed or an error message. In case of failure, the message will contain the error details.")
+        },
+        required = listOf("success", "message")
+    ),
+    annotations = {
+        // Add additional metadata about the tool
+        this
+    }
 ) {
     val serial = inputSerial
 
@@ -39,24 +51,17 @@ fun createCheckAdbSpeedTool(): RegisteredTool = createTool(
         val usbInformation = usbProtocolParser(proc.inputReader().readText())
 
         val match = usbInformation.firstOrNull { it.serial.equals(serial, true) }
-        val messagePrefix = serial
         if (match != null) {
             val speedMessage = if (match.speed.contains("Mb/s", true)) {
                 "\uD83D\uDE82 ${match.speed}"
             } else {
                 "\uD83D\uDE85\uD83D\uDCA8 ${match.speed}"
             }
-            CallToolResult(
-                content = listOf(TextContent("$messagePrefix connected with $speedMessage"))
-            )
+            "$serial connected with $speedMessage".asStructuredResponse(successful = true)
         } else {
-            CallToolResult(
-                content = listOf(TextContent("Failed to retrieve speed for $messagePrefix"))
-            )
+            "Failed to retrieve speed for $serial".asStructuredResponse()
         }
     } else {
-        CallToolResult(
-            content = listOf(TextContent("This tool is only available on Mac OS X. Wrong system."))
-        )
+        "This tool is only available on Mac OS X. Wrong system.".asStructuredResponse()
     }
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CheckAdbSpeedTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/CheckAdbSpeedTool.kt
@@ -19,7 +19,7 @@ fun createCheckAdbSpeedTool(): RegisteredTool = createTool(
     description = """
         Checks the usb connection speed of the Android device for the provided serial.
     """.trimIndent(),
-    inputSchema = DEVICE_FILTER_TOOL_INPUT,
+    inputSchema = SERIAL_ONLY_TOOL_INPUT,
     outputSchema = Tool.Output(
         properties = buildJsonObject {
             applyDefaultOutputSchema(messageDescription = "A message containing the USB connection speed or an error message. In case of failure, the message will contain the error details.")
@@ -27,8 +27,11 @@ fun createCheckAdbSpeedTool(): RegisteredTool = createTool(
         required = listOf("success", "message")
     ),
     annotations = {
-        // Add additional metadata about the tool
-        this
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
     }
 ) {
     val serial = inputSerial

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/FileSystemTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/FileSystemTool.kt
@@ -11,9 +11,7 @@ import com.mikepenz.adbfriend.extensions.escapeForSync
 import com.mikepenz.adbfriend.subcommands.mcp.exception.ToolException
 import com.mikepenz.adbfriend.subcommands.mcp.utils.*
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
-import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +26,7 @@ import java.nio.file.Files
  */
 private fun createListFilesTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "list-files",
     description = """
@@ -79,8 +77,12 @@ private fun createListFilesTool(
             })
         }
     ),
-    annotations = { 
-        copy(destructiveHint = true)
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
     }
 ) {
     val serial = inputSerial
@@ -94,6 +96,7 @@ private fun createListFilesTool(
 
         // Build the result JSON
         val result = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("path", JsonPrimitive(path))
             put("recursive", JsonPrimitive(recursive))
             put("files", buildJsonArray {
@@ -126,7 +129,7 @@ private fun createListFilesTool(
  */
 private fun createReadFileTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "read-file",
     description = """
@@ -134,7 +137,31 @@ private fun createReadFileTool(
         Returns the file content as text.
         This API will not work for binary files.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the file was read successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path of the file that was read"))
+            })
+            put("content", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The textual content of the file"))
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
+    }
 ) {
     val serial = inputSerial
     val path = inputPath
@@ -148,11 +175,10 @@ private fun createReadFileTool(
         )
 
         if (response.errorOutput.isNotBlank()) {
-            CallToolResult(
-                content = listOf(TextContent("Failed to read file: ${response.errorOutput}"))
-            )
+            "Failed to read file: ${response.errorOutput}".asStructuredResponse()
         } else {
             val result = buildJsonObject {
+                put("success", JsonPrimitive(true))
                 put("path", JsonPrimitive(path))
                 put("content", JsonPrimitive(response.output))
             }
@@ -172,7 +198,7 @@ private fun createReadFileTool(
  */
 private fun createWriteFileTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "write-file",
     description = """
@@ -180,7 +206,27 @@ private fun createWriteFileTool(
         Creates the file if it doesn't exist, or overwrites it if it does.
         Use with caution as this can overwrite important files on the device.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_CONTENT_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_CONTENT_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the file was written successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path of the file that was written"))
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
+    }
 ) {
     val serial = inputSerial
     val path = inputPath
@@ -216,12 +262,13 @@ private fun createWriteFileTool(
         }
 
         val result = buildJsonObject {
-            put("path", JsonPrimitive(path))
             put("success", JsonPrimitive(true))
+            put("path", JsonPrimitive(path))
         }
 
         CallToolResult(
-            content = listOf(TextContent(result.toString()))
+            structuredContent = result,
+            content = listOf()
         )
     } catch (e: Exception) {
         "Failed to write file: ${e.message}".asStructuredResponse()
@@ -233,14 +280,34 @@ private fun createWriteFileTool(
  */
 private fun createCreateDirectoryTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "create-directory",
     description = """
         Creates a directory on the Android device.
         Creates parent directories if they don't exist.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the directory was created successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path of the directory that was created"))
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
+    }
 ) {
     val serial = inputSerial
     val path = inputPath
@@ -254,17 +321,16 @@ private fun createCreateDirectoryTool(
         )
 
         if (response.errorOutput.isNotBlank()) {
-            CallToolResult(
-                content = listOf(TextContent("Failed to create directory: ${response.errorOutput}"))
-            )
+            "Failed to create directory: ${response.errorOutput}".asStructuredResponse()
         } else {
             val result = buildJsonObject {
-                put("path", JsonPrimitive(path))
                 put("success", JsonPrimitive(true))
+                put("path", JsonPrimitive(path))
             }
 
             CallToolResult(
-                content = listOf(TextContent(result.toString()))
+                structuredContent = result,
+                content = listOf()
             )
         }
     } catch (e: Exception) {
@@ -277,7 +343,7 @@ private fun createCreateDirectoryTool(
  */
 private fun createDeleteTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "delete",
     description = """
@@ -285,7 +351,31 @@ private fun createDeleteTool(
         Use the 'recursive' parameter to delete directories recursively.
         Use with extreme caution as this can delete important files on the device.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_RECURSIVE_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_RECURSIVE_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the delete operation was executed successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path that was deleted"))
+            })
+            put("recursive", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether the delete operation was recursive"))
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
+    }
 ) {
     val serial = inputSerial
     val path = inputPath
@@ -307,17 +397,17 @@ private fun createDeleteTool(
         )
 
         if (response.errorOutput.isNotBlank()) {
-            CallToolResult(
-                content = listOf(TextContent("Failed to delete: ${response.errorOutput}"))
-            )
+            "Failed to delete: ${response.errorOutput}".asStructuredResponse()
         } else {
             val result = buildJsonObject {
-                put("path", JsonPrimitive(path))
                 put("success", JsonPrimitive(true))
+                put("path", JsonPrimitive(path))
+                put("recursive", JsonPrimitive(recursive))
             }
 
             CallToolResult(
-                content = listOf(TextContent(result.toString()))
+                structuredContent = result,
+                content = listOf()
             )
         }
     } catch (e: Exception) {
@@ -329,7 +419,7 @@ private fun createDeleteTool(
  * Creates a tool for listing allowed directories on an Android device.
  */
 private fun createListAllowedDirectoriesTool(
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "list-allowed-directories",
     description = """
@@ -337,16 +427,41 @@ private fun createListAllowedDirectoriesTool(
         Use this to understand which directories are available on the Android device before trying to access files.
         This API does not return information about allowed paths on the host system.
     """.trimIndent(),
-    inputSchema = Tool.Input()
+    inputSchema = Tool.Input(),
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the list of allowed directories was retrieved successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("allowedDirectories", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("The list of directories allowed on the Android device"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("string"))
+                })
+            })
+        },
+        required = listOf("success", "allowedDirectories")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
+    }
 ) {
     CallToolResult(
-        content = listOf(TextContent(buildJsonObject {
+        structuredContent = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("allowedDirectories", buildJsonArray {
                 allowedPaths.forEach { path ->
                     add(JsonPrimitive(path))
                 }
             })
-        }.toString()))
+        },
+        content = listOf()
     )
 }
 
@@ -355,7 +470,7 @@ private fun createListAllowedDirectoriesTool(
  * Creates a tool for listing allowed directories on an Android device.
  */
 private fun createListAllowedHostDirectoriesTool(
-    hostAllowedPaths: List<String>
+    hostAllowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "list-allowed-host-directories",
     description = """
@@ -363,16 +478,41 @@ private fun createListAllowedHostDirectoriesTool(
         Use this to understand which directories are available on the host system before trying to access files.
         This API does not return information about allowed paths on the android device.
     """.trimIndent(),
-    inputSchema = Tool.Input()
+    inputSchema = Tool.Input(),
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the list of allowed host directories was retrieved successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("allowedDirectories", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("The list of directories allowed on the host system"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("string"))
+                })
+            })
+        },
+        required = listOf("success", "allowedDirectories")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
+    }
 ) {
     CallToolResult(
-        content = listOf(TextContent(buildJsonObject {
+        structuredContent = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("allowedDirectories", buildJsonArray {
                 hostAllowedPaths.forEach { path ->
                     add(JsonPrimitive(path))
                 }
             })
-        }.toString()))
+        },
+        content = listOf()
     )
 }
 
@@ -381,7 +521,7 @@ private fun createListAllowedHostDirectoriesTool(
  */
 private fun createMoveFilesTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "move-files",
     description = """
@@ -390,7 +530,48 @@ private fun createMoveFilesTool(
         Both source and destination paths for each provided item must be within the allowed paths.
         Use caution as this can overwrite important files on the device.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_MOVE_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_MOVE_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether all move operations were processed",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("operations", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("The list of per-operation results"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("source", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The source file path on the Android device"))
+                        })
+                        put("destination", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The destination file path on the Android device"))
+                        })
+                        put("success", buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put("description", JsonPrimitive("Whether the move operation succeeded"))
+                        })
+                        put("error", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Error message if the operation failed"))
+                        })
+                    })
+                })
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
+    }
 ) {
     val serial = inputSerial
     val operations = inputOperations
@@ -398,6 +579,7 @@ private fun createMoveFilesTool(
 
     try {
         val results = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("operations", buildJsonArray {
                 operations.forEach { operation ->
                     try {
@@ -439,7 +621,8 @@ private fun createMoveFilesTool(
         }
 
         CallToolResult(
-            content = listOf(TextContent(results.toString()))
+            structuredContent = results,
+            content = listOf()
         )
     } catch (e: Exception) {
         "Failed to process move operations: ${e.message}".asStructuredResponse()
@@ -451,7 +634,7 @@ private fun createMoveFilesTool(
  */
 private fun createReadMultipleFilesTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "read-multiple-files",
     description = """
@@ -459,7 +642,48 @@ private fun createReadMultipleFilesTool(
         Returns the file contents as text for each file.
         This helps reduce the number of LLM calls needed when reading multiple files.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_MULTIPLE_FILES_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_MULTIPLE_FILES_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the files were processed successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("files", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("Per-file results including path, content (if successful), and errors (if any)"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("path", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The path of the file that was read"))
+                        })
+                        put("content", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The textual content of the file if read successfully"))
+                        })
+                        put("success", buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put("description", JsonPrimitive("Whether the file was read successfully"))
+                        })
+                        put("error", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Error message if the file could not be read"))
+                        })
+                    })
+                })
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
+    }
 ) {
     val serial = inputSerial
     val paths = inputPaths
@@ -473,6 +697,7 @@ private fun createReadMultipleFilesTool(
 
     try {
         val results = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("files", buildJsonArray {
                 paths.forEach { path ->
                     try {
@@ -485,7 +710,11 @@ private fun createReadMultipleFilesTool(
                         val error = response.errorOutput.isNotBlank()
                         add(buildJsonObject {
                             put("path", JsonPrimitive(path))
-                            put("error", JsonPrimitive(response.errorOutput))
+                            if (!error) {
+                                put("content", JsonPrimitive(response.output))
+                            } else {
+                                put("error", JsonPrimitive(response.errorOutput))
+                            }
                             put("success", JsonPrimitive(!error))
                         })
                     } catch (e: Exception) {
@@ -500,7 +729,8 @@ private fun createReadMultipleFilesTool(
         }
 
         CallToolResult(
-            content = listOf(TextContent(results.toString()))
+            structuredContent = results,
+            content = listOf()
         )
     } catch (e: Exception) {
         "Failed to read multiple files: ${e.message}".asStructuredResponse()
@@ -512,14 +742,67 @@ private fun createReadMultipleFilesTool(
  */
 private fun createSearchFilesTool(
     adb: AndroidDebugBridgeClient,
-    allowedPaths: List<String>
+    allowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "search-files",
     description = """
         Searches for files on the Android device matching a case-insensitive glob pattern within the specified path or alternative within the allowed paths on the Android device.
         Returns information about each matching file including name, path, size, type.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_SEARCH_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_SEARCH_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the search operation was executed successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("basePath", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The base path where the search was performed (if provided)"))
+            })
+            put("pattern", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The glob pattern used for the search"))
+            })
+            put("recursive", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether the search was performed recursively"))
+            })
+            put("matchingFiles", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("List of files matching the search criteria"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("name", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The name of the file"))
+                        })
+                        put("path", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The full path of the matching file"))
+                        })
+                        put("size", buildJsonObject {
+                            put("type", JsonPrimitive("integer"))
+                            put("description", JsonPrimitive("The size of the file in bytes"))
+                        })
+                        put("isDirectory", buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put("description", JsonPrimitive("Whether the item is a directory"))
+                        })
+                    })
+                })
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
+    }
 ) {
     val serial = inputSerial
     val path = arguments["path"]?.jsonPrimitive?.content
@@ -562,15 +845,18 @@ private fun createSearchFilesTool(
         }
 
         val result = buildJsonObject {
-            put("basePath", JsonPrimitive(path))
+            put("success", JsonPrimitive(true))
+            if (path != null) put("basePath", JsonPrimitive(path))
             put("pattern", JsonPrimitive(pattern))
+            put("recursive", JsonPrimitive(recursive))
             put("matchingFiles", buildJsonArray {
                 fileDetails.forEach { add(it) }
             })
         }
 
         CallToolResult(
-            content = listOf(TextContent(result.toString()))
+            structuredContent = result,
+            content = listOf()
         )
     } catch (e: Exception) {
         "Failed to search files: ${e.message}".asStructuredResponse()
@@ -583,7 +869,7 @@ private fun createSearchFilesTool(
 private fun createCopyFileToHostTool(
     adb: AndroidDebugBridgeClient,
     allowedPaths: List<String>,
-    hostAllowedPaths: List<String>
+    hostAllowedPaths: List<String>,
 ): RegisteredTool = createTool(
     name = "copy-file-to-host",
     description = """
@@ -593,13 +879,55 @@ private fun createCopyFileToHostTool(
         This tool works with both text and binary files. This tool does not work for directories.
         Use with caution as this can overwrite existing files on the host system.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_COPY_TO_HOST_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_COPY_TO_HOST_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether all copy operations were processed",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
+            put("operations", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("The list of per-operation results"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("android-path", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The source file path on the Android device"))
+                        })
+                        put("host-path", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The destination file path on the host system"))
+                        })
+                        put("success", buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put("description", JsonPrimitive("Whether the copy operation succeeded"))
+                        })
+                        put("error", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("Error message if the operation failed"))
+                        })
+                    })
+                })
+            })
+        },
+        required = listOf("success")
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
+    }
 ) {
     val serial = inputSerial
     val operations = inputOperations
     if (operations.isEmpty()) throw ToolException("At least one copy operation must be provided.")
     try {
         val results = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("operations", buildJsonArray {
                 operations.forEach { operation ->
                     try {
@@ -660,7 +988,8 @@ private fun createCopyFileToHostTool(
         }
 
         CallToolResult(
-            content = listOf(TextContent(results.toString()))
+            structuredContent = results,
+            content = listOf()
         )
     } catch (e: Exception) {
         "Failed to process copy operations: ${e.message}".asStructuredResponse()

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/FileSystemTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/FileSystemTool.kt
@@ -13,6 +13,7 @@ import com.mikepenz.adbfriend.subcommands.mcp.utils.*
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +36,52 @@ private fun createListFilesTool(
         Returns information about each file/directory including name, size, type, and last modified time.
         Use the 'recursive' parameter to list files in subdirectories recursively.
     """.trimIndent(),
-    inputSchema = FILE_SYSTEM_RECURSIVE_TOOL_INPUT
+    inputSchema = FILE_SYSTEM_RECURSIVE_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            applyDefaultOutputSchema()
+            put("path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path that was listed"))
+            })
+            put("recursive", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether the listing was recursive"))
+            })
+            put("files", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("List of files and directories at the specified path"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("name", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The name of the file or directory"))
+                        })
+                        put("path", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The full path of the file or directory"))
+                        })
+                        put("size", buildJsonObject {
+                            put("type", JsonPrimitive("integer"))
+                            put("description", JsonPrimitive("The size of the file in bytes"))
+                        })
+                        put("isDirectory", buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put("description", JsonPrimitive("Whether the item is a directory"))
+                        })
+                        put("lastModified", buildJsonObject {
+                            put("type", JsonPrimitive("integer"))
+                            put("description", JsonPrimitive("The last modified time as a Unix timestamp"))
+                        })
+                    })
+                })
+            })
+        }
+    ),
+    annotations = { 
+        copy(destructiveHint = true)
+    }
 ) {
     val serial = inputSerial
     val path = inputPath
@@ -67,12 +113,11 @@ private fun createListFilesTool(
         }
 
         CallToolResult(
-            content = listOf(TextContent(result.toString()))
+            structuredContent = result,
+            content = listOf()
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to list files: ${e.message}"))
-        )
+        "Failed to list files: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -113,13 +158,12 @@ private fun createReadFileTool(
             }
 
             CallToolResult(
-                content = listOf(TextContent(result.toString()))
+                structuredContent = result,
+                content = listOf()
             )
         }
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to read file: ${e.message}"))
-        )
+        "Failed to read file: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -180,9 +224,7 @@ private fun createWriteFileTool(
             content = listOf(TextContent(result.toString()))
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to write file: ${e.message}"))
-        )
+        "Failed to write file: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -226,9 +268,7 @@ private fun createCreateDirectoryTool(
             )
         }
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to create directory: ${e.message}"))
-        )
+        "Failed to create directory: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -281,9 +321,7 @@ private fun createDeleteTool(
             )
         }
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to delete: ${e.message}"))
-        )
+        "Failed to delete: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -404,9 +442,7 @@ private fun createMoveFilesTool(
             content = listOf(TextContent(results.toString()))
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to process move operations: ${e.message}"))
-        )
+        "Failed to process move operations: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -467,9 +503,7 @@ private fun createReadMultipleFilesTool(
             content = listOf(TextContent(results.toString()))
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to read multiple files: ${e.message}"))
-        )
+        "Failed to read multiple files: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -539,9 +573,7 @@ private fun createSearchFilesTool(
             content = listOf(TextContent(result.toString()))
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to search files: ${e.message}"))
-        )
+        "Failed to search files: ${e.message}".asStructuredResponse()
     }
 }
 
@@ -631,9 +663,7 @@ private fun createCopyFileToHostTool(
             content = listOf(TextContent(results.toString()))
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to process copy operations: ${e.message}"))
-        )
+        "Failed to process copy operations: ${e.message}".asStructuredResponse()
     }
 }
 

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstallApkTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstallApkTool.kt
@@ -10,6 +10,8 @@ import com.mikepenz.adbfriend.subcommands.mcp.utils.inputApkPath
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +33,27 @@ fun createInstallApkTool(
         The APK file must be located within the allowed host paths.
         Use with caution as this can install potentially harmful applications.
     """.trimIndent(),
-    inputSchema = INSTALL_APK_TOOL_INPUT
+    inputSchema = INSTALL_APK_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            put("success", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether the APK was installed successfully"))
+            })
+            put("apk_path", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The path to the APK file on the host system"))
+            })
+            put("message", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("A message describing the result of the installation"))
+            })
+        }
+    ),
+    annotations = { 
+        // Add additional metadata about the tool
+        this
+    }
 ) {
     val serial = inputSerial
     val apkPath = inputApkPath

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstallApkTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstallApkTool.kt
@@ -5,13 +5,9 @@ import com.malinskiy.adam.request.Feature
 import com.malinskiy.adam.request.pkg.InstallRemotePackageRequest
 import com.malinskiy.adam.request.sync.v2.PushFileRequest
 import com.mikepenz.adbfriend.subcommands.mcp.exception.ToolException
-import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.inputApkPath
-import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
+import com.mikepenz.adbfriend.subcommands.mcp.utils.*
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
-import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +21,7 @@ import java.io.File
  */
 fun createInstallApkTool(
     adb: AndroidDebugBridgeClient,
-    hostAllowedPaths: List<String>? = null
+    hostAllowedPaths: List<String>? = null,
 ): RegisteredTool = createTool(
     name = "install-apk",
     description = """
@@ -36,23 +32,23 @@ fun createInstallApkTool(
     inputSchema = INSTALL_APK_TOOL_INPUT,
     outputSchema = Tool.Output(
         properties = buildJsonObject {
-            put("success", buildJsonObject {
-                put("type", JsonPrimitive("boolean"))
-                put("description", JsonPrimitive("Whether the APK was installed successfully"))
-            })
+            applyDefaultOutputSchema(
+                successDescription = "Whether the APK was installed successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
             put("apk_path", buildJsonObject {
                 put("type", JsonPrimitive("string"))
                 put("description", JsonPrimitive("The path to the APK file on the host system"))
             })
-            put("message", buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("A message describing the result of the installation"))
-            })
-        }
+        },
+        required = listOf("success")
     ),
-    annotations = { 
-        // Add additional metadata about the tool
-        this
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false,
+            destructiveHint = true,
+        )
     }
 ) {
     val serial = inputSerial
@@ -97,25 +93,25 @@ fun createInstallApkTool(
         if (success) {
             // Return success result
             CallToolResult(
-                content = listOf(TextContent(buildJsonObject {
+                structuredContent = buildJsonObject {
                     put("success", JsonPrimitive(true))
                     put("apk_path", JsonPrimitive(apkPath))
                     put("message", JsonPrimitive("APK installed successfully"))
-                }.toString()))
+                },
+                content = listOf()
             )
         } else {
             // Return error result
             CallToolResult(
-                content = listOf(TextContent(buildJsonObject {
+                structuredContent = buildJsonObject {
                     put("success", JsonPrimitive(false))
                     put("apk_path", JsonPrimitive(apkPath))
                     put("message", JsonPrimitive("Failed to install APK: ${installResponse.output.trim()}"))
-                }.toString()))
+                },
+                content = listOf()
             )
         }
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to install APK: ${e.message}"))
-        )
+        "Failed to install APK: ${e.message}".asStructuredResponse()
     }
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstalledPackageTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstalledPackageTool.kt
@@ -6,6 +6,7 @@ import io.modelcontextprotocol.kotlin.sdk.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import kotlinx.serialization.json.*
@@ -128,7 +129,32 @@ private fun MutableList<RegisteredTool>.addInstalledPackageTool(
                 required = listOf(
                     "serial", "package-names"
                 )
-            )
+            ),
+            outputSchema = Tool.Output(
+                properties = buildJsonObject {
+                    put("results", buildJsonObject {
+                        put("type", JsonPrimitive("array"))
+                        put("description", JsonPrimitive("Results of the operation for each package"))
+                        put("items", buildJsonObject {
+                            put("type", JsonPrimitive("object"))
+                            put("properties", buildJsonObject {
+                                put("packageName", buildJsonObject {
+                                    put("type", JsonPrimitive("string"))
+                                    put("description", JsonPrimitive("The package name"))
+                                })
+                                put("successful", buildJsonObject {
+                                    put("type", JsonPrimitive("boolean"))
+                                    put("description", JsonPrimitive("Whether the operation was successful for this package"))
+                                })
+                            })
+                        })
+                    })
+                }
+            ),
+            annotations = { 
+                // Add additional metadata about the tool
+                this
+            }
         ) {
             val serial = arguments["serial"]?.jsonPrimitive?.content?.trim()
             val packageNames = arguments["package-names"]?.jsonArray

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstalledPackageTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/InstalledPackageTool.kt
@@ -2,13 +2,13 @@ package com.mikepenz.adbfriend.subcommands.mcp.tools
 
 import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.shell.v2.ShellCommandRequest
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
+import com.mikepenz.adbfriend.subcommands.mcp.utils.asStructuredResponse
+import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import io.modelcontextprotocol.kotlin.sdk.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
-import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import kotlinx.serialization.json.*
 
 
@@ -105,7 +105,7 @@ private fun MutableList<RegisteredTool>.addInstalledPackageTool(
     name: String,
     description: String,
     extraProperties: Map<String, JsonObject> = emptyMap(),
-    block: suspend CallToolRequest.(adb: AndroidDebugBridgeClient, serial: String, packageNames: Array<String>) -> Map<String, Boolean>
+    block: suspend CallToolRequest.(adb: AndroidDebugBridgeClient, serial: String, packageNames: Array<String>) -> Map<String, Boolean>,
 ) {
     add(
         createTool(
@@ -125,13 +125,17 @@ private fun MutableList<RegisteredTool>.addInstalledPackageTool(
                         })
                         put("description", JsonPrimitive("The array of package names to clear the data for."))
                     })
-                }, 
+                },
                 required = listOf(
                     "serial", "package-names"
                 )
             ),
             outputSchema = Tool.Output(
                 properties = buildJsonObject {
+                    applyDefaultOutputSchema(
+                        successDescription = "Whether the operation was executed successfully",
+                        messageDescription = "An optional status message informing about errors during execution"
+                    )
                     put("results", buildJsonObject {
                         put("type", JsonPrimitive("array"))
                         put("description", JsonPrimitive("Results of the operation for each package"))
@@ -140,7 +144,7 @@ private fun MutableList<RegisteredTool>.addInstalledPackageTool(
                             put("properties", buildJsonObject {
                                 put("packageName", buildJsonObject {
                                     put("type", JsonPrimitive("string"))
-                                    put("description", JsonPrimitive("The package name"))
+                                    put("description", JsonPrimitive("The android package name"))
                                 })
                                 put("successful", buildJsonObject {
                                     put("type", JsonPrimitive("boolean"))
@@ -149,28 +153,29 @@ private fun MutableList<RegisteredTool>.addInstalledPackageTool(
                             })
                         })
                     })
-                }
+                },
+                required = listOf("success")
             ),
-            annotations = { 
-                // Add additional metadata about the tool
-                this
+            annotations = {
+                copy(
+                    readOnlyHint = false,
+                    openWorldHint = false,
+                    destructiveHint = true,
+                )
             }
         ) {
             val serial = arguments["serial"]?.jsonPrimitive?.content?.trim()
             val packageNames = arguments["package-names"]?.jsonArray
 
             if (serial.isNullOrBlank()) {
-                CallToolResult(
-                    content = listOf(TextContent("The 'serial' parameter is required."))
-                )
+                "The 'serial' parameter is required.".asStructuredResponse()
             } else if (packageNames.isNullOrEmpty()) {
-                CallToolResult(
-                    content = listOf(TextContent("The 'package-names' parameter is required."))
-                )
+                "The 'package-names' parameter is required.".asStructuredResponse()
             } else {
                 val results = block(adb, serial, packageNames.map { it.jsonPrimitive.content }.toTypedArray())
 
                 val result = buildJsonObject {
+                    put("success", JsonPrimitive(true))
                     put("results", buildJsonArray {
                         results.onEach { (packageName, result) ->
                             add(buildJsonObject {
@@ -182,7 +187,8 @@ private fun MutableList<RegisteredTool>.addInstalledPackageTool(
                 }
 
                 CallToolResult(
-                    content = listOf(TextContent(result.toString()))
+                    structuredContent = result,
+                    content = listOf()
                 )
             }
         }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListConnectedDevicesTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListConnectedDevicesTool.kt
@@ -3,11 +3,11 @@ package com.mikepenz.adbfriend.subcommands.mcp.tools
 import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.device.Device
 import com.mikepenz.adbfriend.extensions.fetchModel
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
+import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import kotlinx.serialization.json.*
 
 fun createConnectedDevicesTool(adb: AndroidDebugBridgeClient, devices: List<Device>): RegisteredTool = createTool(
@@ -38,6 +38,10 @@ fun createConnectedDevicesTool(adb: AndroidDebugBridgeClient, devices: List<Devi
     ),
     outputSchema = Tool.Output(
         properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the connected devices were retrieved successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
             put("devices", buildJsonObject {
                 put("type", JsonPrimitive("array"))
                 put("description", JsonPrimitive("List of connected Android devices"))
@@ -59,17 +63,22 @@ fun createConnectedDevicesTool(adb: AndroidDebugBridgeClient, devices: List<Devi
                     })
                 })
             })
-        }
+        },
+        required = listOf("success")
     ),
-    annotations = { 
-        // Add additional metadata about the tool
-        this
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
     }
 ) {
     val serial = arguments["serial"]?.jsonPrimitive?.content?.trim()
     val name = arguments["name"]?.jsonPrimitive?.content?.trim()
 
     val result = buildJsonObject {
+        put("success", JsonPrimitive(true))
         put("devices", buildJsonArray {
             devices.onEach { device ->
                 if (serial.isNullOrBlank() || serial.equals(device.serial, true)) {

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListConnectedDevicesTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListConnectedDevicesTool.kt
@@ -35,7 +35,36 @@ fun createConnectedDevicesTool(adb: AndroidDebugBridgeClient, devices: List<Devi
             )
         ),
         required = listOf()
-    )
+    ),
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            put("devices", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("List of connected Android devices"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("serial", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The device serial number"))
+                        })
+                        put("model", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The device model name"))
+                        })
+                        put("state", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The device state (e.g., ONLINE, OFFLINE)"))
+                        })
+                    })
+                })
+            })
+        }
+    ),
+    annotations = { 
+        // Add additional metadata about the tool
+        this
+    }
 ) {
     val serial = arguments["serial"]?.jsonPrimitive?.content?.trim()
     val name = arguments["name"]?.jsonPrimitive?.content?.trim()
@@ -59,6 +88,7 @@ fun createConnectedDevicesTool(adb: AndroidDebugBridgeClient, devices: List<Devi
     }
 
     CallToolResult(
-        content = listOf(TextContent(result.toString()))
+        structuredContent = result,
+        content = listOf()
     )
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListInstalledPackagesTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListInstalledPackagesTool.kt
@@ -2,15 +2,14 @@ package com.mikepenz.adbfriend.subcommands.mcp.tools
 
 import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.shell.v2.ShellCommandRequest
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
+import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
+import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import com.mikepenz.adbfriend.utils.convertGlobToRegex
 import com.mikepenz.adbfriend.utils.packageParser
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
-import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
-import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -27,6 +26,10 @@ fun createGetInstalledPackagesTool(adb: AndroidDebugBridgeClient): RegisteredToo
     inputSchema = DEVICE_FILTER_TOOL_INPUT,
     outputSchema = Tool.Output(
         properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the installed packages were retrieved successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
             put("packages", buildJsonObject {
                 put("type", JsonPrimitive("array"))
                 put("description", JsonPrimitive("List of installed packages on the Android device"))
@@ -48,11 +51,15 @@ fun createGetInstalledPackagesTool(adb: AndroidDebugBridgeClient): RegisteredToo
                     })
                 })
             })
-        }
+        },
+        required = listOf("success")
     ),
-    annotations = { 
-        // Add additional metadata about the tool
-        this
+    annotations = {
+        copy(
+            readOnlyHint = true,
+            openWorldHint = false,
+            destructiveHint = false,
+        )
     }
 ) {
     val serial = inputSerial
@@ -88,6 +95,7 @@ fun createGetInstalledPackagesTool(adb: AndroidDebugBridgeClient): RegisteredToo
     }
 
     val result = buildJsonObject {
+        put("success", JsonPrimitive(true))
         put("packages", buildJsonArray {
             filtered.onEach { pack ->
                 add(buildJsonObject {
@@ -100,6 +108,7 @@ fun createGetInstalledPackagesTool(adb: AndroidDebugBridgeClient): RegisteredToo
     }
 
     CallToolResult(
-        content = listOf(TextContent(result.toString()))
+        structuredContent = result,
+        content = listOf()
     )
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListInstalledPackagesTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ListInstalledPackagesTool.kt
@@ -7,6 +7,7 @@ import com.mikepenz.adbfriend.utils.packageParser
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
@@ -23,7 +24,36 @@ fun createGetInstalledPackagesTool(adb: AndroidDebugBridgeClient): RegisteredToo
         The `packageName` is the common identifier used to access any other package specific tool.
         Use the `third-party-only` flag to filter out system applications and only show third-party applications.
     """.trimIndent(),
-    inputSchema = DEVICE_FILTER_TOOL_INPUT
+    inputSchema = DEVICE_FILTER_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            put("packages", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("List of installed packages on the Android device"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("packageName", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The package name"))
+                        })
+                        put("version", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The package version"))
+                        })
+                        put("dataDir", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The package data directory"))
+                        })
+                    })
+                })
+            })
+        }
+    ),
+    annotations = { 
+        // Add additional metadata about the tool
+        this
+    }
 ) {
     val serial = inputSerial
 

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ProxyTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ProxyTool.kt
@@ -2,12 +2,12 @@ package com.mikepenz.adbfriend.subcommands.mcp.tools
 
 import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.shell.v2.ShellCommandRequest
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
+import com.mikepenz.adbfriend.subcommands.mcp.utils.asStructuredResponse
 import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
-import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 
@@ -50,13 +50,13 @@ fun createProxyTool(adb: AndroidDebugBridgeClient): RegisteredTool = createTool(
     inputSchema = PROXY_TOOL_INPUT,
     outputSchema = Tool.Output(
         properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the proxy configuration was successful",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
             put("serial", buildJsonObject {
                 put("type", JsonPrimitive("string"))
                 put("description", JsonPrimitive("The device serial number"))
-            })
-            put("success", buildJsonObject {
-                put("type", JsonPrimitive("boolean"))
-                put("description", JsonPrimitive("Whether the proxy configuration was successful"))
             })
             put("enabled", buildJsonObject {
                 put("type", JsonPrimitive("boolean"))
@@ -82,12 +82,14 @@ fun createProxyTool(adb: AndroidDebugBridgeClient): RegisteredTool = createTool(
                 put("type", JsonPrimitive("string"))
                 put("description", JsonPrimitive("An error message (if the operation failed)"))
             })
-        }
+        },
+        required = listOf("success")
     ),
     annotations = {
         copy(
             readOnlyHint = false,
-            openWorldHint = false
+            openWorldHint = false,
+            destructiveHint = true,
         )
     }
 ) {
@@ -100,14 +102,10 @@ fun createProxyTool(adb: AndroidDebugBridgeClient): RegisteredTool = createTool(
         val proxyValue = if (enabled) {
             // Validate required parameters when enabling proxy
             if (host.isNullOrBlank()) {
-                return@createTool CallToolResult(
-                    content = listOf(TextContent("Host parameter is required when enabling proxy"))
-                )
+                return@createTool "Host parameter is required when enabling proxy".asStructuredResponse()
             }
             if (port == null || port < 1 || port > 65535) {
-                return@createTool CallToolResult(
-                    content = listOf(TextContent("Valid port parameter (1-65535) is required when enabling proxy"))
-                )
+                return@createTool "Valid port parameter (1-65535) is required when enabling proxy".asStructuredResponse()
             }
             "$host:$port"
         } else {
@@ -157,11 +155,10 @@ fun createProxyTool(adb: AndroidDebugBridgeClient): RegisteredTool = createTool(
         }
 
         CallToolResult(
-            content = listOf(TextContent(result.toString()))
+            structuredContent = result,
+            content = listOf()
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to configure proxy: ${e.message}"))
-        )
+        "Failed to configure proxy: ${e.message}".asStructuredResponse()
     }
 }

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ProxyTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ProxyTool.kt
@@ -7,6 +7,8 @@ import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
+import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 
 /**
@@ -38,14 +40,56 @@ internal val PROXY_TOOL_INPUT = Tool.Input(
  * Creates a tool for configuring HTTP proxy settings on Android devices.
  * This tool can set or disable the global HTTP proxy configuration.
  */
-fun createProxyTool(adb: AndroidDebugBridgeClient): io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool = createTool(
+fun createProxyTool(adb: AndroidDebugBridgeClient): RegisteredTool = createTool(
     name = "configure-proxy",
     description = """
         Configures HTTP proxy settings on an Android device.
         Can set a proxy server with host and port, or disable the proxy entirely.
         Uses the global http_proxy setting which affects system-wide network connections.
     """.trimIndent(),
-    inputSchema = PROXY_TOOL_INPUT
+    inputSchema = PROXY_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            put("serial", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The device serial number"))
+            })
+            put("success", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether the proxy configuration was successful"))
+            })
+            put("enabled", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether the proxy is enabled"))
+            })
+            put("host", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The proxy server host (if enabled and successful)"))
+            })
+            put("port", buildJsonObject {
+                put("type", JsonPrimitive("integer"))
+                put("description", JsonPrimitive("The proxy server port (if enabled and successful)"))
+            })
+            put("proxy", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The proxy configuration string (if enabled and successful)"))
+            })
+            put("currentValue", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The current proxy configuration value (if verification was successful)"))
+            })
+            put("error", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("An error message (if the operation failed)"))
+            })
+        }
+    ),
+    annotations = {
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false
+        )
+    }
 ) {
     val serial = inputSerial
     val enabled = arguments["enabled"]?.jsonPrimitive?.booleanOrNull ?: true

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/Spec.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/Spec.kt
@@ -25,6 +25,15 @@ internal val OUTPUT_PATH_INPUT = buildJsonObject {
     put("description", JsonPrimitive("The path on the host system where the file should be saved. If not provided, a default path will be used."))
 }
 
+internal val SERIAL_ONLY_TOOL_INPUT = Tool.Input(
+    properties = JsonObject(
+        mapOf(
+            "serial" to SERIAL_INPUT
+        )
+    ),
+    required = listOf("serial")
+)
+
 internal val DEVICE_FILTER_TOOL_INPUT = Tool.Input(
     properties = JsonObject(
         mapOf(

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/TestConfigurationTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/TestConfigurationTool.kt
@@ -2,12 +2,12 @@ package com.mikepenz.adbfriend.subcommands.mcp.tools
 
 import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.shell.v2.ShellCommandRequest
+import com.mikepenz.adbfriend.subcommands.mcp.utils.applyDefaultOutputSchema
+import com.mikepenz.adbfriend.subcommands.mcp.utils.asStructuredResponse
 import com.mikepenz.adbfriend.subcommands.mcp.utils.createTool
 import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
-import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 
@@ -65,6 +65,10 @@ fun createTestConfigurationTool(adb: AndroidDebugBridgeClient): RegisteredTool =
     inputSchema = TEST_CONFIGURATION_TOOL_INPUT,
     outputSchema = Tool.Output(
         properties = buildJsonObject {
+            applyDefaultOutputSchema(
+                successDescription = "Whether the device configuration operations executed successfully",
+                messageDescription = "An optional status message informing about errors during execution"
+            )
             put("serial", buildJsonObject {
                 put("type", JsonPrimitive("string"))
                 put("description", JsonPrimitive("The device serial number"))
@@ -106,13 +110,14 @@ fun createTestConfigurationTool(adb: AndroidDebugBridgeClient): RegisteredTool =
                     })
                 })
             })
-        }
+        },
+        required = listOf("success")
     ),
-    annotations = { 
-        // Add additional metadata about the tool
+    annotations = {
         copy(
             readOnlyHint = false,
-            openWorldHint = false
+            openWorldHint = false,
+            destructiveHint = true,
         )
     }
 ) {
@@ -302,18 +307,18 @@ fun createTestConfigurationTool(adb: AndroidDebugBridgeClient): RegisteredTool =
 
         // Build the final result
         val result = buildJsonObject {
+            put("success", JsonPrimitive(true))
             put("serial", JsonPrimitive(serial))
             put("completeSuccess", JsonPrimitive(completeSuccess))
             put("operations", JsonArray(results))
         }
 
         CallToolResult(
-            content = listOf(TextContent(result.toString()))
+            structuredContent = result,
+            content = listOf()
         )
     } catch (e: Exception) {
-        CallToolResult(
-            content = listOf(TextContent("Failed to configure device for testing: ${e.message}"))
-        )
+        "Failed to configure device for testing: ${e.message}".asStructuredResponse()
     }
 }
 

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/TestConfigurationTool.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/TestConfigurationTool.kt
@@ -7,6 +7,8 @@ import com.mikepenz.adbfriend.subcommands.mcp.utils.inputSerial
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
+import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 
 /**
@@ -53,14 +55,66 @@ internal val TEST_CONFIGURATION_TOOL_INPUT = Tool.Input(
  * This tool can disable animations, set immersive mode, reset autofill service, enable touches,
  * unlock the device, and collapse the statusbar.
  */
-fun createTestConfigurationTool(adb: AndroidDebugBridgeClient): io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool = createTool(
+fun createTestConfigurationTool(adb: AndroidDebugBridgeClient): RegisteredTool = createTool(
     name = "configure-test-device",
     description = """
         Configures an Android device for testing by setting various flags and options.
         Can disable animations, set immersive mode, reset autofill service, enable touches,
         unlock the device, and collapse the statusbar.
     """.trimIndent(),
-    inputSchema = TEST_CONFIGURATION_TOOL_INPUT
+    inputSchema = TEST_CONFIGURATION_TOOL_INPUT,
+    outputSchema = Tool.Output(
+        properties = buildJsonObject {
+            put("serial", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("The device serial number"))
+            })
+            put("completeSuccess", buildJsonObject {
+                put("type", JsonPrimitive("boolean"))
+                put("description", JsonPrimitive("Whether all operations were successful"))
+            })
+            put("operations", buildJsonObject {
+                put("type", JsonPrimitive("array"))
+                put("description", JsonPrimitive("List of operations performed on the device"))
+                put("items", buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put("properties", buildJsonObject {
+                        put("operation", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The name of the operation"))
+                        })
+                        put("success", buildJsonObject {
+                            put("type", JsonPrimitive("boolean"))
+                            put("description", JsonPrimitive("Whether the operation was successful"))
+                        })
+                        put("details", buildJsonObject {
+                            put("type", JsonPrimitive("array"))
+                            put("description", JsonPrimitive("Additional details about the operation (for animations)"))
+                        })
+                        put("error", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("An error message if the operation failed"))
+                        })
+                        put("value", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The current value (for immersiveMode)"))
+                        })
+                        put("previousValue", buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                            put("description", JsonPrimitive("The previous value (for resetAutofillService)"))
+                        })
+                    })
+                })
+            })
+        }
+    ),
+    annotations = { 
+        // Add additional metadata about the tool
+        copy(
+            readOnlyHint = false,
+            openWorldHint = false
+        )
+    }
 ) {
     val serial = inputSerial
     val animations = arguments["animations"]?.jsonPrimitive?.booleanOrNull ?: true

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ToolRegistry.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/tools/ToolRegistry.kt
@@ -7,7 +7,7 @@ fun buildTools(
     adb: AndroidDebugBridgeClient,
     devices: List<Device>,
     allowedPaths: List<String> = DEFAULT_ALLOWED_PATHS,
-    hostAllowedPaths: List<String> = getDefaultHostAllowedPaths()
+    hostAllowedPaths: List<String> = getDefaultHostAllowedPaths(),
 ) = buildList {
     add(createCheckAdbSpeedTool())
     addAll(createInstalledPackageTools(adb))

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/AdbUtil.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/AdbUtil.kt
@@ -60,7 +60,7 @@ internal suspend fun AndroidDebugBridgeClient.listFiles(
     serial: String,
     path: String,
     allowedPaths: List<String>,
-    recursive: Boolean = false
+    recursive: Boolean = false,
 ): List<Pair<String, com.malinskiy.adam.request.sync.model.FileEntry>> {
     val allFiles = mutableListOf<Pair<String, com.malinskiy.adam.request.sync.model.FileEntry>>()
 

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/McpServer.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/McpServer.kt
@@ -45,7 +45,8 @@ private fun configureServer(builtTools: List<RegisteredTool>): Server {
         ),
         ServerOptions(
             capabilities = ServerCapabilities(
-                tools = ServerCapabilities.Tools(listChanged = false)
+                tools = ServerCapabilities.Tools(listChanged = false),
+                logging = null
             )
         )
     )

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/ToolUtil.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/ToolUtil.kt
@@ -46,7 +46,7 @@ fun String.asStructuredResponse(successful: Boolean = false): CallToolResult {
 
 fun JsonObjectBuilder.applyDefaultOutputSchema(
     successDescription: String = "Whether the operations was executed successfully",
-    messageDescription: String = "In case of failure, the message will contain the error details."
+    messageDescription: String = "In case of failure, the message will contain the error details.",
 ) {
     put("success", buildJsonObject {
         put("type", JsonPrimitive("boolean"))

--- a/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/ToolUtil.kt
+++ b/adbfriend-cli/src/main/kotlin/com/mikepenz/adbfriend/subcommands/mcp/utils/ToolUtil.kt
@@ -3,9 +3,9 @@ package com.mikepenz.adbfriend.subcommands.mcp.utils
 import com.mikepenz.adbfriend.subcommands.mcp.exception.ToolException
 import io.modelcontextprotocol.kotlin.sdk.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.Tool
 import io.modelcontextprotocol.kotlin.sdk.Tool.Input
+import io.modelcontextprotocol.kotlin.sdk.ToolAnnotations
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 
@@ -16,21 +16,46 @@ fun createTool(
     description: String?,
     /** A JSON object defining the expected parameters for the tool. */
     inputSchema: Input,
-    handler: suspend CallToolRequest.() -> CallToolResult
+    outputSchema: Tool.Output = Tool.Output(),
+    annotations: ToolAnnotations.() -> ToolAnnotations = { this },
+    handler: suspend CallToolRequest.() -> CallToolResult,
 ): RegisteredTool = RegisteredTool(
     Tool(
         name = name,
         description = description,
-        inputSchema = inputSchema
+        inputSchema = inputSchema,
+        outputSchema = outputSchema,
+        annotations = annotations(ToolAnnotations(title = name))
     ),
 ) {
     return@RegisteredTool try {
         handler(it)
     } catch (t: ToolException) {
-        CallToolResult(content = listOf(TextContent(t.message)))
+        t.message.asStructuredResponse()
     } catch (t: Throwable) {
-        CallToolResult(content = listOf(TextContent("An unhandled exception occurred while using the tool: ${t.message}")))
+        "An unhandled exception occurred while using the tool: ${t.message}".asStructuredResponse()
     }
+}
+
+fun String.asStructuredResponse(successful: Boolean = false): CallToolResult {
+    return CallToolResult(content = listOf(), structuredContent = buildJsonObject {
+        put("success", JsonPrimitive(successful))
+        put("message", JsonPrimitive(this@asStructuredResponse))
+    })
+}
+
+fun JsonObjectBuilder.applyDefaultOutputSchema(
+    successDescription: String = "Whether the operations was executed successfully",
+    messageDescription: String = "In case of failure, the message will contain the error details."
+) {
+    put("success", buildJsonObject {
+        put("type", JsonPrimitive("boolean"))
+        put("description", JsonPrimitive(successDescription))
+    })
+    put("message", buildJsonObject {
+        put("type", JsonPrimitive("string"))
+        put("description", JsonPrimitive(messageDescription))
+    })
 }
 
 val CallToolRequest.inputSerial: String

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=1.8.2
-VERSION_CODE=10802
+VERSION_NAME=2.0.0
+VERSION_CODE=20000
 
 # Turn on parallel compilation, caching and on-demand configuration
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # convention plugin
 com.mikepenz.version-catalog-update.enabled=true
+com.mikepenz.binary-compatibility-validator.enabled=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,14 @@ adam = "0.5.10"
 clikt = "5.0.3"
 mordant = "3.0.2"
 slf4j = "2.0.17"
-shadow = "8.1.1"
+shadow = "9.0.2"
 buildconfig = "5.6.7"
 mcp = "0.5.0"
 kotlinx-io = "0.8.0"
-ktor = "3.2.0"
+ktor = "3.2.2"
 
 [plugins]
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ mordant = "3.0.2"
 slf4j = "2.0.17"
 shadow = "9.0.2"
 buildconfig = "5.6.7"
-mcp = "0.5.0"
+mcp = "0.6.0"
 kotlinx-io = "0.8.0"
 ktor = "3.2.2"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("baseLibs") {
-            from("com.mikepenz:version-catalog:0.6.0")
+            from("com.mikepenz:version-catalog:0.8.4")
         }
     }
 }


### PR DESCRIPTION
Update build tools and dependencies 
- Bump Gradle to 9.0.0
- Upgrade Shadow plugin to 9.0.2 with new plugin ID
- Update Ktor to 3.2.2
- Use version-catalog 0.8.4
- Disable binary-compatibility-validator
work in progress to introduce structured output spec for all tools
Introduce structured output specs for all tools 
- Apply consistent structured output schemas across tools for improved consistency and error handling.
- Add required fields like `success` and `message` descriptions in all output schemas.
- Refactor annotations to reflect better operation metadata like `readOnlyHint` and `destructiveHint`.
- Replace text responses with structured responses for better API conformity.